### PR TITLE
Set readline pin to the default pin 7.0

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,9 +1,23 @@
+c_compiler:
+- toolchain_c
 curl:
 - '7.59'
+gmp:
+- '6'
+openssl:
+- 1.0.2
 perl:
 - '5.26'
 pin_run_as_build:
   curl:
     max_pin: x
+  gmp:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   perl:
     max_pin: x.x
+  readline:
+    max_pin: x.x
+readline:
+- '7.0'

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -1,15 +1,29 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+c_compiler:
+- toolchain_c
 curl:
 - '7.59'
+gmp:
+- '6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+openssl:
+- 1.0.2
 perl:
 - '5.26'
 pin_run_as_build:
   curl:
     max_pin: x
+  gmp:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   perl:
     max_pin: x.x
+  readline:
+    max_pin: x.x
+readline:
+- '7.0'

--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -29,7 +29,7 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 
-test -d "$ARTIFACTS" || mkdir "$ARTIFACTS"
+mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,21 +22,24 @@ source:
     - patches/stackwarn.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage('pari', max_pin='x.x') }}
 
 requirements:
   build:
-    - toolchain
+    - {{ compiler('c') }}
     - libtool
-    - gmp >=5.0.1,<7
-    - readline 6.3*
-    - perl 5.22.0.1
     - curl
-    - openssl 1.0.*
+  host:
+    - gmp
+    - readline
+    - openssl
+    - perl
   run:
-    - gmp >=5.0.1,<7
-    - readline 6.3*
+    - gmp
+    - readline
     - perl
 
 test:


### PR DESCRIPTION
Does it hurt to do such a run_exports? Programs could be talking to pari
through its command line interface. Then the pin would be too restrictive.