### PR TITLE
Relocate Windows import libraries to lib folder and create `pari.lib` for MSVC

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -74,3 +74,19 @@ fi
 
 make install install-lib-sta AR=${AR} RANLIB=${RANLIB} STRIP=${STRIP}
 cp "src/language/anal.h" "$PREFIX/include/pari/anal.h"
+
+# Relocate Windows import libraries (libpari*.dll.a) from bin -> lib
+# so that linkers find them in the conventional location.
+# Also create lib file for MSVC compiler.
+if [[ "$target_platform" == win-* ]]; then
+  mkdir -p "$PREFIX/lib"
+  for implib in "$PREFIX"/bin/libpari*.dll.a; do
+    basename=$(basename "$implib" .dll.a)
+    echo "Relocating import library $implib to /lib/";
+    mv "$implib" "$PREFIX/lib/" || exit 1
+
+    echo "Generating lib file for $basename"
+    gendef "$PREFIX/bin/$basename.dll"
+    $HOST-dlltool -d "$basename.def" -l "$PREFIX/lib/$basename.lib"
+  done
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.17.2" %}
 {% set name = "pari" %}
-{% set build_num = "4" %}
+{% set build_num = "5" %}
 {% set posix = "m2-" if build_platform.startswith("win-") else '' %}
 
 package:
@@ -70,6 +70,8 @@ test:
     - if not exist %LIBRARY_INC%\pari\pari.h exit 1                        # [win]
     - if not exist %LIBRARY_INC%\pari\anal.h exit 1                        # [win]
     - if not exist %LIBRARY_BIN%\libpari.dll exit 1                        # [win]
+    - if not exist %LIBRARY_LIB%\libpari.dll.a exit 1                      # [win]
+    - if not exist %LIBRARY_LIB%\libpari.lib exit 1                        # [win]
     - if not exist %LIBRARY_BIN%\libpari-gmp.dll exit 1                    # [win and variant == "single"]
     - if not exist %LIBRARY_BIN%\libpari-gmp-tls.dll exit 1                # [win and variant == "pthread"]
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

The `libpari.dll.a` was under `bin`, but the conventional location would be under `lib` if I'm not mistaken. Also create a `libpari.lib` file so that MSVC can find the dll. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
